### PR TITLE
Feature: 로그인/로그아웃 기능 구현 완료

### DIFF
--- a/.github/workflows/test-report.yml
+++ b/.github/workflows/test-report.yml
@@ -21,7 +21,7 @@ jobs:
         image: mysql:8.0.34
         env:
           MYSQL_DATABASE: on_and_off_test
-          MYSQL_USER: root
+          MYSQL_USER: tigers
           MYSQL_PASSWORD: 1234
           MYSQL_ROOT_PASSWORD: 1234
         ports:
@@ -36,6 +36,19 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '17'
+
+      - name: Copy application.yml
+        run: |
+          mkdir ./src/main/resources
+          touch ./src/main/resources/application.yml
+          echo "${{ secrets.APPLICATION }}" > ./src/main/resources/application.yml
+          touch ./src/main/resources/application-jwt.yml
+          echo "${{ secrets.APPLICATION_JWT }}" > ./src/main/resources/application-jwt.yml
+          touch ./src/main/resources/application-release.yml
+          echo "${{ secrets.APPLICATION_RELEASE }}" > ./src/main/resources/application-release.yml
+          touch ./src/main/resources/application-test.yml
+          echo "${{ secrets.APPLICATION_TEST }}" > ./src/main/resources/application-test.yml
+          find src/main/resources
 
       - name: Cache Gradle packages
         uses: actions/cache@v3

--- a/.gitignore
+++ b/.gitignore
@@ -35,4 +35,4 @@ out/
 
 ### VS Code ###
 .vscode/
-application.yml
+application*.yml

--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ dependencies {
     runtimeOnly 'com.mysql:mysql-connector-j'
 
     // Logging
-    implementation 'com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.9.0'
+//    implementation 'com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.9.0'
 
     // Lombok
     compileOnly 'org.projectlombok:lombok'
@@ -49,6 +49,9 @@ dependencies {
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.2'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.2'
     implementation 'io.jsonwebtoken:jjwt-api:0.12.2'
+
+    // Password Encoder
+    implementation 'org.mindrot:jbcrypt:0.4'
 }
 
 tasks.named('bootBuildImage') {

--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,11 @@ dependencies {
 
     // Test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+
+    // JWT
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.2'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.2'
+    implementation 'io.jsonwebtoken:jjwt-api:0.12.2'
 }
 
 tasks.named('bootBuildImage') {

--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id 'org.springframework.boot' version '3.1.5'
     id 'io.spring.dependency-management' version '1.1.3'
     id 'jacoco'
+    id 'org.asciidoctor.jvm.convert' version '3.3.2'
 }
 
 group = 'site'
@@ -20,6 +21,8 @@ configurations {
     compileOnly {
         extendsFrom annotationProcessor
     }
+
+    asciidoctorExt
 }
 
 repositories {
@@ -52,6 +55,10 @@ dependencies {
 
     // Password Encoder
     implementation 'org.mindrot:jbcrypt:0.4'
+
+    // REST Docs
+    asciidoctorExt 'org.springframework.restdocs:spring-restdocs-asciidoctor'
+    testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
 }
 
 tasks.named('bootBuildImage') {
@@ -60,6 +67,10 @@ tasks.named('bootBuildImage') {
 
 tasks.named('test') {
     useJUnitPlatform()
+}
+
+ext {
+    snippetsDir = file('build/generated-snippets')
 }
 
 test {
@@ -72,5 +83,25 @@ jacocoTestReport {
     reports {
         xml.required.set(true)
         html.required.set(true)
+    }
+}
+
+asciidoctor {
+    inputs.dir snippetsDir
+    configurations 'asciidoctorExt'
+
+    sources {
+        include("**/index.adoc")
+    }
+
+    baseDirFollowsSourceFile()
+    dependsOn test
+}
+
+bootJar {
+    dependsOn asciidoctor
+
+    from("${asciidoctor.outputDir}") {
+        into 'static/docs'
     }
 }

--- a/src/main/java/site/onandoff/auth/Account.java
+++ b/src/main/java/site/onandoff/auth/Account.java
@@ -1,0 +1,14 @@
+package site.onandoff.auth;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+public class Account {
+
+	private long id;
+
+}

--- a/src/main/java/site/onandoff/auth/application/AuthManager.java
+++ b/src/main/java/site/onandoff/auth/application/AuthManager.java
@@ -18,7 +18,6 @@ public class AuthManager {
 	private static final String AUTHORIZATION_PREFIX = "Bearer ";
 
 	private final MemberRepository memberRepository;
-	private final PasswordEncoder passwordEncoder;
 
 	public String validateAuthorizationHeader(String authorizationHeader) {
 		if (authorizationHeader == null || !authorizationHeader.startsWith(AUTHORIZATION_PREFIX)) {
@@ -32,7 +31,7 @@ public class AuthManager {
 		Member member = memberRepository.findByEmailAndProvider(loginData.getEmail(), Provider.LOCAL)
 			.orElseThrow(InvalidLoginException::new);
 
-		if (passwordEncoder.isMatch(loginData.getPassword(), member.getPassword())) {
+		if (PasswordEncoder.isMatch(loginData.getPassword(), member.getPassword())) {
 			return member;
 		}
 

--- a/src/main/java/site/onandoff/auth/application/AuthManager.java
+++ b/src/main/java/site/onandoff/auth/application/AuthManager.java
@@ -1,0 +1,42 @@
+package site.onandoff.auth.application;
+
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+import site.onandoff.auth.dto.LoginData;
+import site.onandoff.exception.auth.AuthorizationHeaderException;
+import site.onandoff.exception.auth.InvalidLoginException;
+import site.onandoff.member.Member;
+import site.onandoff.member.MemberRepository;
+import site.onandoff.member.Provider;
+import site.onandoff.util.PasswordEncoder;
+
+@Component
+@RequiredArgsConstructor
+public class AuthManager {
+
+	private static final String AUTHORIZATION_PREFIX = "Bearer ";
+
+	private final MemberRepository memberRepository;
+	private final PasswordEncoder passwordEncoder;
+
+	public String validateAuthorizationHeader(String authorizationHeader) {
+		if (authorizationHeader == null || !authorizationHeader.startsWith(AUTHORIZATION_PREFIX)) {
+			throw new AuthorizationHeaderException();
+		}
+
+		return authorizationHeader.substring(AUTHORIZATION_PREFIX.length());
+	}
+
+	public Member authenticateLoginData(LoginData loginData) {
+		Member member = memberRepository.findByEmailAndProvider(loginData.getEmail(), Provider.LOCAL)
+			.orElseThrow(InvalidLoginException::new);
+
+		if (passwordEncoder.isMatch(loginData.getPassword(), member.getPassword())) {
+			return member;
+		}
+
+		throw new InvalidLoginException();
+	}
+
+}

--- a/src/main/java/site/onandoff/auth/application/AuthService.java
+++ b/src/main/java/site/onandoff/auth/application/AuthService.java
@@ -1,0 +1,31 @@
+package site.onandoff.auth.application;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+import site.onandoff.auth.Account;
+import site.onandoff.auth.dto.AuthenticationTokens;
+import site.onandoff.auth.dto.LoginData;
+import site.onandoff.member.Member;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class AuthService {
+
+	private final AuthManager authManager;
+	private final TokenManager tokenManager;
+
+	@Transactional
+	public AuthenticationTokens login(LoginData loginData) {
+		Member member = authManager.authenticateLoginData(loginData);
+		return tokenManager.issueTokens(member.getId());
+	}
+
+	@Transactional
+	public AuthenticationTokens reissueTokens(Account account) {
+		return tokenManager.issueTokens(account.getId());
+	}
+
+}

--- a/src/main/java/site/onandoff/auth/application/AuthService.java
+++ b/src/main/java/site/onandoff/auth/application/AuthService.java
@@ -5,8 +5,9 @@ import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
 import site.onandoff.auth.Account;
-import site.onandoff.auth.dto.AuthenticationTokens;
+import site.onandoff.auth.dto.AuthenticationTokenPair;
 import site.onandoff.auth.dto.LoginData;
+import site.onandoff.auth.dto.ReissuedAccessToken;
 import site.onandoff.member.Member;
 
 @Service
@@ -18,14 +19,14 @@ public class AuthService {
 	private final TokenManager tokenManager;
 
 	@Transactional
-	public AuthenticationTokens login(LoginData loginData) {
+	public AuthenticationTokenPair login(LoginData loginData) {
 		Member member = authManager.authenticateLoginData(loginData);
-		return tokenManager.issueTokens(member.getId());
+		return tokenManager.issueTokenPair(member.getId());
 	}
 
 	@Transactional
-	public AuthenticationTokens reissueTokens(Account account) {
-		return tokenManager.issueTokens(account.getId());
+	public ReissuedAccessToken reissueAccessToken(Account account) {
+		return tokenManager.issueAccessToken(account.getId());
 	}
 
 }

--- a/src/main/java/site/onandoff/auth/application/AuthService.java
+++ b/src/main/java/site/onandoff/auth/application/AuthService.java
@@ -18,13 +18,11 @@ public class AuthService {
 	private final AuthManager authManager;
 	private final TokenManager tokenManager;
 
-	@Transactional
 	public AuthenticationTokenPair login(LoginData loginData) {
 		Member member = authManager.authenticateLoginData(loginData);
 		return tokenManager.issueTokenPair(member.getId());
 	}
 
-	@Transactional
 	public ReissuedAccessToken reissueAccessToken(Account account) {
 		return tokenManager.issueAccessToken(account.getId());
 	}

--- a/src/main/java/site/onandoff/auth/application/TokenManager.java
+++ b/src/main/java/site/onandoff/auth/application/TokenManager.java
@@ -1,0 +1,80 @@
+package site.onandoff.auth.application;
+
+import java.util.Date;
+import java.util.Map;
+
+import org.springframework.stereotype.Component;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.UnsupportedJwtException;
+import io.jsonwebtoken.security.Keys;
+import io.jsonwebtoken.security.SignatureException;
+import lombok.RequiredArgsConstructor;
+import site.onandoff.auth.dto.AuthenticationTokens;
+import site.onandoff.exception.auth.ExpiredTokenException;
+import site.onandoff.exception.auth.InvalidTokenException;
+
+@Component
+@RequiredArgsConstructor
+public class TokenManager {
+
+	private final TokenProperties tokenProperties;
+
+	public AuthenticationTokens issueTokens(Long id) {
+		String accessToken = generateToken(Map.of("id", id, "refresh", false),
+			tokenProperties.getAccessTokenDuration());
+		String refreshToken = generateToken(Map.of("id", id, "refresh", true),
+			tokenProperties.getRefreshTokenDuration());
+		return new AuthenticationTokens(accessToken, refreshToken);
+	}
+
+	private String generateToken(Map<String, Object> claims, long duration) {
+		Date now = new Date();
+		Date expiry = new Date(now.getTime() + duration);
+
+		return Jwts.builder()
+			.claims(claims)
+			.issuer(tokenProperties.getIssuer())
+			.issuedAt(now)
+			.expiration(expiry)
+			.signWith(Keys.hmacShaKeyFor(tokenProperties.getSecret().getBytes()))
+			.compact();
+	}
+
+	public Claims validateAccessToken(String accessToken) {
+		Claims claims = parse(accessToken);
+		if (claims.get("refresh", Boolean.class)) {
+			throw new InvalidTokenException();
+		}
+
+		return parse(accessToken);
+	}
+
+	public Claims validateRefreshToken(String refreshToken) {
+		Claims claims = parse(refreshToken);
+		if (claims.get("refresh", Boolean.class)) {
+			return claims;
+		}
+
+		throw new InvalidTokenException();
+	}
+
+	private Claims parse(String token) {
+		try {
+			return Jwts.parser()
+				.verifyWith(Keys.hmacShaKeyFor(tokenProperties.getSecret().getBytes()))
+				.build()
+				.parseSignedClaims(token)
+				.getPayload();
+		} catch (
+			ExpiredJwtException e) {
+			throw new ExpiredTokenException();
+		} catch (UnsupportedJwtException | MalformedJwtException | SignatureException e) {
+			throw new InvalidTokenException();
+		}
+	}
+
+}

--- a/src/main/java/site/onandoff/auth/application/TokenManager.java
+++ b/src/main/java/site/onandoff/auth/application/TokenManager.java
@@ -13,7 +13,8 @@ import io.jsonwebtoken.UnsupportedJwtException;
 import io.jsonwebtoken.security.Keys;
 import io.jsonwebtoken.security.SignatureException;
 import lombok.RequiredArgsConstructor;
-import site.onandoff.auth.dto.AuthenticationTokens;
+import site.onandoff.auth.dto.AuthenticationTokenPair;
+import site.onandoff.auth.dto.ReissuedAccessToken;
 import site.onandoff.exception.auth.ExpiredTokenException;
 import site.onandoff.exception.auth.InvalidTokenException;
 
@@ -23,12 +24,18 @@ public class TokenManager {
 
 	private final TokenProperties tokenProperties;
 
-	public AuthenticationTokens issueTokens(Long id) {
+	public AuthenticationTokenPair issueTokenPair(Long id) {
 		String accessToken = generateToken(Map.of("id", id, "refresh", false),
 			tokenProperties.getAccessTokenDuration());
 		String refreshToken = generateToken(Map.of("id", id, "refresh", true),
 			tokenProperties.getRefreshTokenDuration());
-		return new AuthenticationTokens(accessToken, refreshToken);
+		return new AuthenticationTokenPair(accessToken, refreshToken);
+	}
+
+	public ReissuedAccessToken issueAccessToken(Long id) {
+		String accessToken = generateToken(Map.of("id", id, "refresh", false),
+			tokenProperties.getAccessTokenDuration());
+		return new ReissuedAccessToken(accessToken);
 	}
 
 	private String generateToken(Map<String, Object> claims, long duration) {

--- a/src/main/java/site/onandoff/auth/application/TokenProperties.java
+++ b/src/main/java/site/onandoff/auth/application/TokenProperties.java
@@ -1,0 +1,20 @@
+package site.onandoff.auth.application;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@ConfigurationProperties("jwt")
+@RequiredArgsConstructor
+@Getter
+public class TokenProperties {
+
+	private final long accessTokenDuration;
+	private final long refreshTokenDuration;
+	private final String issuer;
+	private final String secret;
+
+}

--- a/src/main/java/site/onandoff/auth/application/TokenProperties.java
+++ b/src/main/java/site/onandoff/auth/application/TokenProperties.java
@@ -1,12 +1,10 @@
 package site.onandoff.auth.application;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.stereotype.Component;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
-@Component
 @ConfigurationProperties("jwt")
 @RequiredArgsConstructor
 @Getter

--- a/src/main/java/site/onandoff/auth/dto/AuthenticationTokenPair.java
+++ b/src/main/java/site/onandoff/auth/dto/AuthenticationTokenPair.java
@@ -5,7 +5,7 @@ import lombok.Getter;
 
 @AllArgsConstructor
 @Getter
-public class AuthenticationTokens {
+public class AuthenticationTokenPair {
 
 	private String accessToken;
 	private String refreshToken;

--- a/src/main/java/site/onandoff/auth/dto/AuthenticationTokens.java
+++ b/src/main/java/site/onandoff/auth/dto/AuthenticationTokens.java
@@ -1,0 +1,13 @@
+package site.onandoff.auth.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class AuthenticationTokens {
+
+	private String accessToken;
+	private String refreshToken;
+
+}

--- a/src/main/java/site/onandoff/auth/dto/LoginData.java
+++ b/src/main/java/site/onandoff/auth/dto/LoginData.java
@@ -1,5 +1,6 @@
 package site.onandoff.auth.dto;
 
+import jakarta.validation.constraints.Pattern;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -7,7 +8,11 @@ import lombok.NoArgsConstructor;
 @Getter
 public class LoginData {
 
+	@Pattern(regexp = "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$", message = "이메일 형식이 올바르지 않습니다")
 	private String email;
+
+	@Pattern(regexp = "^(?=.*[a-zA-Z])(?=.*\\d)(?=.*[!@#$%^&*()_+\\-=\\[\\]{};':\"\\\\|,.<>\\/?]).{8,16}$",
+		message = "비밀번호는 8자 이상 16자 이하로, 영문, 숫자, 특수문자를 최소 1개씩 포함해야 합니다")
 	private String password;
 
 }

--- a/src/main/java/site/onandoff/auth/dto/LoginData.java
+++ b/src/main/java/site/onandoff/auth/dto/LoginData.java
@@ -1,0 +1,13 @@
+package site.onandoff.auth.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@Getter
+public class LoginData {
+
+	private String email;
+	private String password;
+
+}

--- a/src/main/java/site/onandoff/auth/dto/LoginData.java
+++ b/src/main/java/site/onandoff/auth/dto/LoginData.java
@@ -1,10 +1,12 @@
 package site.onandoff.auth.dto;
 
 import jakarta.validation.constraints.Pattern;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @NoArgsConstructor
+@AllArgsConstructor
 @Getter
 public class LoginData {
 

--- a/src/main/java/site/onandoff/auth/dto/ReissuedAccessToken.java
+++ b/src/main/java/site/onandoff/auth/dto/ReissuedAccessToken.java
@@ -1,0 +1,12 @@
+package site.onandoff.auth.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class ReissuedAccessToken {
+
+	private String accessToken;
+
+}

--- a/src/main/java/site/onandoff/auth/presentation/AuthController.java
+++ b/src/main/java/site/onandoff/auth/presentation/AuthController.java
@@ -6,6 +6,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import site.onandoff.auth.Account;
 import site.onandoff.auth.application.AuthService;
@@ -21,7 +22,7 @@ public class AuthController {
 	private final AuthService authService;
 
 	@PostMapping("/login")
-	public ApiResponse<AuthenticationTokens> login(@RequestBody LoginData loginData) {
+	public ApiResponse<AuthenticationTokens> login(@RequestBody @Valid LoginData loginData) {
 		return ApiResponse.ok(LOGIN_SUCCESS.getMessage(), authService.login(loginData));
 	}
 

--- a/src/main/java/site/onandoff/auth/presentation/AuthController.java
+++ b/src/main/java/site/onandoff/auth/presentation/AuthController.java
@@ -10,8 +10,9 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import site.onandoff.auth.Account;
 import site.onandoff.auth.application.AuthService;
-import site.onandoff.auth.dto.AuthenticationTokens;
+import site.onandoff.auth.dto.AuthenticationTokenPair;
 import site.onandoff.auth.dto.LoginData;
+import site.onandoff.auth.dto.ReissuedAccessToken;
 import site.onandoff.util.ApiResponse;
 import site.onandoff.util.Login;
 
@@ -22,14 +23,13 @@ public class AuthController {
 	private final AuthService authService;
 
 	@PostMapping("/login")
-	public ApiResponse<AuthenticationTokens> login(@RequestBody @Valid LoginData loginData) {
+	public ApiResponse<AuthenticationTokenPair> login(@RequestBody @Valid LoginData loginData) {
 		return ApiResponse.ok(LOGIN_SUCCESS.getMessage(), authService.login(loginData));
 	}
 
 	@PostMapping("/reissue")
-	public ApiResponse<AuthenticationTokens> reissueTokens(@Login Account account) {
-		return ApiResponse.ok(REISSUE_TOKENS_SUCCESS.getMessage(),
-			authService.reissueTokens(account));
+	public ApiResponse<ReissuedAccessToken> reissueAccessToken(@Login Account account) {
+		return ApiResponse.ok(REISSUE_TOKENS_SUCCESS.getMessage(), authService.reissueAccessToken(account));
 	}
 
 }

--- a/src/main/java/site/onandoff/auth/presentation/AuthController.java
+++ b/src/main/java/site/onandoff/auth/presentation/AuthController.java
@@ -1,0 +1,34 @@
+package site.onandoff.auth.presentation;
+
+import static site.onandoff.util.ResponseMessage.*;
+
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.RequiredArgsConstructor;
+import site.onandoff.auth.Account;
+import site.onandoff.auth.application.AuthService;
+import site.onandoff.auth.dto.AuthenticationTokens;
+import site.onandoff.auth.dto.LoginData;
+import site.onandoff.util.ApiResponse;
+import site.onandoff.util.Login;
+
+@RestController
+@RequiredArgsConstructor
+public class AuthController {
+
+	private final AuthService authService;
+
+	@PostMapping("/login")
+	public ApiResponse<AuthenticationTokens> login(@RequestBody LoginData loginData) {
+		return ApiResponse.ok(LOGIN_SUCCESS.getMessage(), authService.login(loginData));
+	}
+
+	@PostMapping("/reissue")
+	public ApiResponse<AuthenticationTokens> reissueTokens(@Login Account account) {
+		return ApiResponse.ok(REISSUE_TOKENS_SUCCESS.getMessage(),
+			authService.reissueTokens(account));
+	}
+
+}

--- a/src/main/java/site/onandoff/config/PropertiesConfig.java
+++ b/src/main/java/site/onandoff/config/PropertiesConfig.java
@@ -1,0 +1,12 @@
+package site.onandoff.config;
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+import site.onandoff.auth.application.TokenProperties;
+
+@Configuration
+@EnableConfigurationProperties(value = {TokenProperties.class})
+public class PropertiesConfig {
+	
+}

--- a/src/main/java/site/onandoff/config/WebConfig.java
+++ b/src/main/java/site/onandoff/config/WebConfig.java
@@ -1,0 +1,49 @@
+package site.onandoff.config;
+
+import java.util.List;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import lombok.RequiredArgsConstructor;
+import site.onandoff.interceptor.AccessTokenInterceptor;
+import site.onandoff.interceptor.RefreshTokenInterceptor;
+import site.onandoff.util.LoginArgumentResolver;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebConfig implements WebMvcConfigurer {
+
+	private final AccessTokenInterceptor accessTokenInterceptor;
+	private final RefreshTokenInterceptor refreshTokenInterceptor;
+	private final LoginArgumentResolver loginArgumentResolver;
+
+	@Override
+	public void addCorsMappings(CorsRegistry registry) {
+		registry.addMapping("/**")
+			.allowedOrigins("*")
+			.allowedMethods(
+				HttpMethod.HEAD.name(), HttpMethod.GET.name(), HttpMethod.POST.name(),
+				HttpMethod.PUT.name(), HttpMethod.PATCH.name(), HttpMethod.DELETE.name(),
+				HttpMethod.OPTIONS.name());
+	}
+
+	@Override
+	public void addInterceptors(InterceptorRegistry registry) {
+		registry.addInterceptor(accessTokenInterceptor)
+			.addPathPatterns("/**")
+			.excludePathPatterns("/reissue");
+		registry.addInterceptor(refreshTokenInterceptor)
+			.addPathPatterns("/reissue");
+	}
+
+	@Override
+	public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+		resolvers.add(loginArgumentResolver);
+	}
+
+}

--- a/src/main/java/site/onandoff/exception/CustomException.java
+++ b/src/main/java/site/onandoff/exception/CustomException.java
@@ -1,0 +1,18 @@
+package site.onandoff.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class CustomException extends RuntimeException {
+
+	private final HttpStatus status;
+
+	public CustomException(ErrorType errorType) {
+		super(errorType.getMessage());
+		this.status = errorType.getStatus();
+	}
+
+	public HttpStatus getStatus() {
+		return status;
+	}
+
+}

--- a/src/main/java/site/onandoff/exception/ErrorType.java
+++ b/src/main/java/site/onandoff/exception/ErrorType.java
@@ -1,0 +1,29 @@
+package site.onandoff.exception;
+
+import org.springframework.http.HttpStatus;
+
+public enum ErrorType {
+
+	// Auth
+	INVALID_AUTHORIZATION_HEADER(HttpStatus.BAD_REQUEST, "Authorization 헤더를 찾을 수 없거나 형식이 올바르지 않습니다"),
+	EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "만료된 토큰입니다"),
+	INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다"),
+	INVALID_LOGIN_REQUEST(HttpStatus.UNAUTHORIZED, "유효하지 않은 사용자 정보입니다");
+
+	private final HttpStatus status;
+	private final String message;
+
+	ErrorType(HttpStatus status, String message) {
+		this.status = status;
+		this.message = message;
+	}
+
+	public HttpStatus getStatus() {
+		return this.status;
+	}
+
+	public String getMessage() {
+		return this.message;
+	}
+
+}

--- a/src/main/java/site/onandoff/exception/GlobalExceptionHandler.java
+++ b/src/main/java/site/onandoff/exception/GlobalExceptionHandler.java
@@ -1,7 +1,16 @@
 package site.onandoff.exception;
 
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.springframework.context.support.DefaultMessageSourceResolvable;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindException;
+import org.springframework.validation.FieldError;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import site.onandoff.util.ApiResponse;
@@ -13,6 +22,24 @@ public class GlobalExceptionHandler {
 	public ResponseEntity<ApiResponse<Void>> handleCustomException(CustomException exception) {
 		return ResponseEntity.status(exception.getStatus())
 			.body(ApiResponse.of(exception.getStatus(), exception.getMessage(), null));
+	}
+
+	@ResponseStatus(HttpStatus.BAD_REQUEST)
+	@ExceptionHandler(BindException.class)
+	public ApiResponse<Object> handleBindException(BindException exception) {
+		return ApiResponse.of(HttpStatus.BAD_REQUEST, null,
+			exception.getBindingResult().getFieldErrors().stream()
+				.collect(Collectors.groupingBy(FieldError::getField))
+				.entrySet().stream()
+				.map(error -> {
+					Map<String, Object> fieldError = new HashMap<>();
+					fieldError.put("field", error.getKey());
+					fieldError.put("message", error.getValue().stream()
+						.map(DefaultMessageSourceResolvable::getDefaultMessage)
+						.collect(Collectors.joining(", ")));
+					return fieldError;
+				})
+		);
 	}
 
 }

--- a/src/main/java/site/onandoff/exception/GlobalExceptionHandler.java
+++ b/src/main/java/site/onandoff/exception/GlobalExceptionHandler.java
@@ -1,0 +1,18 @@
+package site.onandoff.exception;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import site.onandoff.util.ApiResponse;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+	@ExceptionHandler(CustomException.class)
+	public ResponseEntity<ApiResponse<Void>> handleCustomException(CustomException exception) {
+		return ResponseEntity.status(exception.getStatus())
+			.body(ApiResponse.of(exception.getStatus(), exception.getMessage(), null));
+	}
+
+}

--- a/src/main/java/site/onandoff/exception/auth/AuthorizationHeaderException.java
+++ b/src/main/java/site/onandoff/exception/auth/AuthorizationHeaderException.java
@@ -1,0 +1,12 @@
+package site.onandoff.exception.auth;
+
+import site.onandoff.exception.CustomException;
+import site.onandoff.exception.ErrorType;
+
+public class AuthorizationHeaderException extends CustomException {
+
+	public AuthorizationHeaderException() {
+		super(ErrorType.INVALID_AUTHORIZATION_HEADER);
+	}
+
+}

--- a/src/main/java/site/onandoff/exception/auth/ExpiredTokenException.java
+++ b/src/main/java/site/onandoff/exception/auth/ExpiredTokenException.java
@@ -1,0 +1,12 @@
+package site.onandoff.exception.auth;
+
+import site.onandoff.exception.CustomException;
+import site.onandoff.exception.ErrorType;
+
+public class ExpiredTokenException extends CustomException {
+
+	public ExpiredTokenException() {
+		super(ErrorType.EXPIRED_TOKEN);
+	}
+
+}

--- a/src/main/java/site/onandoff/exception/auth/InvalidLoginException.java
+++ b/src/main/java/site/onandoff/exception/auth/InvalidLoginException.java
@@ -1,0 +1,12 @@
+package site.onandoff.exception.auth;
+
+import site.onandoff.exception.CustomException;
+import site.onandoff.exception.ErrorType;
+
+public class InvalidLoginException extends CustomException {
+
+	public InvalidLoginException() {
+		super(ErrorType.INVALID_LOGIN_REQUEST);
+	}
+
+}

--- a/src/main/java/site/onandoff/exception/auth/InvalidTokenException.java
+++ b/src/main/java/site/onandoff/exception/auth/InvalidTokenException.java
@@ -1,0 +1,12 @@
+package site.onandoff.exception.auth;
+
+import site.onandoff.exception.CustomException;
+import site.onandoff.exception.ErrorType;
+
+public class InvalidTokenException extends CustomException {
+
+	public InvalidTokenException() {
+		super(ErrorType.INVALID_TOKEN);
+	}
+
+}

--- a/src/main/java/site/onandoff/interceptor/AccessTokenInterceptor.java
+++ b/src/main/java/site/onandoff/interceptor/AccessTokenInterceptor.java
@@ -1,0 +1,67 @@
+package site.onandoff.interceptor;
+
+import java.util.Arrays;
+
+import org.springframework.http.HttpMethod;
+import org.springframework.stereotype.Component;
+import org.springframework.web.cors.CorsUtils;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import io.jsonwebtoken.Claims;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import site.onandoff.auth.application.AuthManager;
+import site.onandoff.auth.application.TokenManager;
+
+@Component
+@RequiredArgsConstructor
+public class AccessTokenInterceptor implements HandlerInterceptor {
+
+	private static final String AUTHORIZATION_HEADER = "Authorization";
+	public static final String ACCOUNT_ID = "id";
+	public static final String ACCOUNT_TOKEN = "token";
+
+	private final AuthManager authManager;
+	private final TokenManager tokenManager;
+
+	@Override
+	public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws
+		Exception {
+		if (CorsUtils.isPreFlightRequest(request))
+			return true;
+
+		if (Whitelist.contains(request))
+			return true;
+
+		String authorizationHeader = request.getHeader(AUTHORIZATION_HEADER);
+		String token = authManager.validateAuthorizationHeader(authorizationHeader);
+
+		Claims claims = tokenManager.validateAccessToken(token);
+
+		request.setAttribute(ACCOUNT_ID, claims.get(ACCOUNT_ID, Long.class));
+		request.setAttribute(ACCOUNT_TOKEN, token);
+		return true;
+	}
+
+	enum Whitelist {
+
+		LOGIN(HttpMethod.POST, "/login");
+
+		private final HttpMethod httpMethod;
+		private final String url;
+
+		Whitelist(HttpMethod httpMethod, String url) {
+			this.httpMethod = httpMethod;
+			this.url = url;
+		}
+
+		public static boolean contains(HttpServletRequest request) {
+			return Arrays.stream(values())
+				.anyMatch(whitelist -> whitelist.httpMethod.name().equals(request.getMethod()) &&
+					whitelist.url.equals(request.getRequestURI()));
+		}
+
+	}
+
+}

--- a/src/main/java/site/onandoff/interceptor/RefreshTokenInterceptor.java
+++ b/src/main/java/site/onandoff/interceptor/RefreshTokenInterceptor.java
@@ -1,0 +1,41 @@
+package site.onandoff.interceptor;
+
+import org.springframework.stereotype.Component;
+import org.springframework.web.cors.CorsUtils;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import io.jsonwebtoken.Claims;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import site.onandoff.auth.application.AuthManager;
+import site.onandoff.auth.application.TokenManager;
+
+@Component
+@RequiredArgsConstructor
+public class RefreshTokenInterceptor implements HandlerInterceptor {
+
+	private static final String AUTHORIZATION_HEADER = "Authorization";
+	public static final String ACCOUNT_ID = "id";
+	public static final String ACCOUNT_TOKEN = "token";
+
+	private final AuthManager authManager;
+	private final TokenManager tokenManager;
+
+	@Override
+	public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws
+		Exception {
+		if (CorsUtils.isPreFlightRequest(request))
+			return true;
+
+		String authorizationHeader = request.getHeader(AUTHORIZATION_HEADER);
+		String token = authManager.validateAuthorizationHeader(authorizationHeader);
+
+		Claims claims = tokenManager.validateRefreshToken(token);
+
+		request.setAttribute(ACCOUNT_ID, claims.get(ACCOUNT_ID, Long.class));
+		request.setAttribute(ACCOUNT_TOKEN, token);
+		return true;
+	}
+
+}

--- a/src/main/java/site/onandoff/member/Member.java
+++ b/src/main/java/site/onandoff/member/Member.java
@@ -1,12 +1,6 @@
 package site.onandoff.member;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
+import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import site.onandoff.util.EntityHistory;
@@ -15,24 +9,28 @@ import site.onandoff.util.EntityHistory;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Member extends EntityHistory {
 
-	@Id
-	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	private Long id;
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
 
-	@Column(nullable = false)
-	private String email;
+    @Column(nullable = false)
+    private String email;
 
-	@Column(unique = true, nullable = false)
-	private String nickname;
+    @Column(unique = true, nullable = false)
+    private String nickname;
 
-	private String password;
+    private String password;
 
-	@Enumerated(value = EnumType.STRING)
-	@Column(nullable = false)
-	private Provider provider;
+    @Enumerated(value = EnumType.STRING)
+    @Column(nullable = false)
+    private Provider provider;
 
 	public Long getId() {
 		return id;
+	}
+
+	public String getPassword() {
+		return password;
 	}
 
 }

--- a/src/main/java/site/onandoff/member/Member.java
+++ b/src/main/java/site/onandoff/member/Member.java
@@ -1,29 +1,37 @@
 package site.onandoff.member;
 
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
 import site.onandoff.util.EntityHistory;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
 public class Member extends EntityHistory {
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
 
-    @Column(nullable = false)
-    private String email;
+	@Column(nullable = false)
+	private String email;
 
-    @Column(unique = true, nullable = false)
-    private String nickname;
+	@Column(unique = true, nullable = false)
+	private String nickname;
 
-    private String password;
+	private String password;
 
-    @Enumerated(value = EnumType.STRING)
-    @Column(nullable = false)
-    private Provider provider;
+	@Enumerated(value = EnumType.STRING)
+	@Column(nullable = false)
+	private Provider provider;
 
 	public Long getId() {
 		return id;

--- a/src/main/java/site/onandoff/member/Member.java
+++ b/src/main/java/site/onandoff/member/Member.java
@@ -1,6 +1,12 @@
 package site.onandoff.member;
 
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import site.onandoff.util.EntityHistory;
@@ -9,20 +15,24 @@ import site.onandoff.util.EntityHistory;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Member extends EntityHistory {
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
 
-    @Column(nullable = false)
-    private String email;
+	@Column(nullable = false)
+	private String email;
 
-    @Column(unique = true, nullable = false)
-    private String nickname;
+	@Column(unique = true, nullable = false)
+	private String nickname;
 
-    private String password;
+	private String password;
 
-    @Enumerated(value = EnumType.STRING)
-    @Column(nullable = false)
-    private Provider provider;
+	@Enumerated(value = EnumType.STRING)
+	@Column(nullable = false)
+	private Provider provider;
+
+	public Long getId() {
+		return id;
+	}
 
 }

--- a/src/main/java/site/onandoff/member/MemberRepository.java
+++ b/src/main/java/site/onandoff/member/MemberRepository.java
@@ -1,0 +1,11 @@
+package site.onandoff.member;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+
+	Optional<Member> findByEmailAndProvider(String email, Provider provider);
+
+}

--- a/src/main/java/site/onandoff/util/ApiResponse.java
+++ b/src/main/java/site/onandoff/util/ApiResponse.java
@@ -23,10 +23,6 @@ public class ApiResponse<T> {
 		return new ApiResponse<>(status, message, data);
 	}
 
-	public static <T> ApiResponse<T> noData(HttpStatus status, String message) {
-		return new ApiResponse<>(status, message, null);
-	}
-
 	public static <T> ApiResponse<T> ok(String message, T data) {
 		return new ApiResponse<>(HttpStatus.OK, message, data);
 	}

--- a/src/main/java/site/onandoff/util/Login.java
+++ b/src/main/java/site/onandoff/util/Login.java
@@ -1,0 +1,12 @@
+package site.onandoff.util;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Login {
+
+}

--- a/src/main/java/site/onandoff/util/LoginArgumentResolver.java
+++ b/src/main/java/site/onandoff/util/LoginArgumentResolver.java
@@ -1,0 +1,30 @@
+package site.onandoff.util;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+import jakarta.servlet.http.HttpServletRequest;
+import site.onandoff.auth.Account;
+
+@Component
+public class LoginArgumentResolver implements HandlerMethodArgumentResolver {
+
+	@Override
+	public boolean supportsParameter(MethodParameter parameter) {
+		return parameter.hasParameterAnnotation(Login.class);
+	}
+
+	@Override
+	public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
+		NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
+		HttpServletRequest request = webRequest.getNativeRequest(HttpServletRequest.class);
+
+		assert request != null;
+		return new Account((long)request.getAttribute("id"));
+	}
+
+}

--- a/src/main/java/site/onandoff/util/PasswordEncoder.java
+++ b/src/main/java/site/onandoff/util/PasswordEncoder.java
@@ -1,16 +1,14 @@
 package site.onandoff.util;
 
 import org.mindrot.jbcrypt.BCrypt;
-import org.springframework.stereotype.Component;
 
-@Component
-public class PasswordEncoder {
+public final class PasswordEncoder {
 
-	public String encrypt(String password) {
+	public static String encrypt(String password) {
 		return BCrypt.hashpw(password, BCrypt.gensalt());
 	}
 
-	public boolean isMatch(String password, String hashed) {
+	public static boolean isMatch(String password, String hashed) {
 		return BCrypt.checkpw(password, hashed);
 	}
 

--- a/src/main/java/site/onandoff/util/PasswordEncoder.java
+++ b/src/main/java/site/onandoff/util/PasswordEncoder.java
@@ -1,0 +1,17 @@
+package site.onandoff.util;
+
+import org.mindrot.jbcrypt.BCrypt;
+import org.springframework.stereotype.Component;
+
+@Component
+public class PasswordEncoder {
+
+	public String encrypt(String password) {
+		return BCrypt.hashpw(password, BCrypt.gensalt());
+	}
+
+	public boolean isMatch(String password, String hashed) {
+		return BCrypt.checkpw(password, hashed);
+	}
+
+}

--- a/src/main/java/site/onandoff/util/ResponseMessage.java
+++ b/src/main/java/site/onandoff/util/ResponseMessage.java
@@ -1,0 +1,19 @@
+package site.onandoff.util;
+
+public enum ResponseMessage {
+
+	// Auth
+	LOGIN_SUCCESS("로그인에 성공했습니다"),
+	REISSUE_TOKENS_SUCCESS("토큰 재발급에 성공했습니다");
+
+	private final String message;
+
+	ResponseMessage(String message) {
+		this.message = message;
+	}
+
+	public String getMessage() {
+		return this.message;
+	}
+
+}

--- a/src/test/java/site/onandoff/IntegrationTestSupport.java
+++ b/src/test/java/site/onandoff/IntegrationTestSupport.java
@@ -8,7 +8,6 @@ import org.springframework.restdocs.RestDocumentationContextProvider;
 import org.springframework.restdocs.RestDocumentationExtension;
 import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
@@ -18,7 +17,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 @SpringBootTest
 @ActiveProfiles("test")
 @ExtendWith(RestDocumentationExtension.class)
-@Sql(value = "classpath:schema.sql", executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD)
 public abstract class IntegrationTestSupport {
 
 	@Autowired

--- a/src/test/java/site/onandoff/IntegrationTestSupport.java
+++ b/src/test/java/site/onandoff/IntegrationTestSupport.java
@@ -1,0 +1,37 @@
+package site.onandoff;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.restdocs.RestDocumentationContextProvider;
+import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@ExtendWith(RestDocumentationExtension.class)
+@Sql(value = "classpath:schema.sql", executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD)
+public abstract class IntegrationTestSupport {
+
+	@Autowired
+	private WebApplicationContext context;
+
+	protected MockMvc mockMvc;
+	protected ObjectMapper objectMapper = new ObjectMapper();
+
+	@BeforeEach
+	void setUp(RestDocumentationContextProvider provider) {
+		this.mockMvc = MockMvcBuilders.webAppContextSetup(this.context)
+			.apply(MockMvcRestDocumentation.documentationConfiguration(provider))
+			.build();
+	}
+
+}

--- a/src/test/java/site/onandoff/auth/AuthTest.java
+++ b/src/test/java/site/onandoff/auth/AuthTest.java
@@ -1,0 +1,185 @@
+package site.onandoff.auth;
+
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.*;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.transaction.annotation.Transactional;
+
+import jakarta.persistence.EntityManager;
+import site.onandoff.IntegrationTestSupport;
+import site.onandoff.auth.application.TokenManager;
+import site.onandoff.auth.dto.LoginData;
+import site.onandoff.member.Member;
+import site.onandoff.member.Provider;
+import site.onandoff.util.PasswordEncoder;
+
+class AuthTest extends IntegrationTestSupport {
+
+	@Autowired
+	EntityManager entityManager;
+
+	@Autowired
+	TokenManager tokenManager;
+
+	@Test
+	@DisplayName("일반 로그인 : 성공")
+	@Transactional
+	void loginSuccess() throws Exception {
+		// given
+		Member member = new Member(
+			null,
+			"yeon@email.com",
+			"yeonise",
+			PasswordEncoder.encrypt("test!1234"),
+			Provider.LOCAL
+		);
+		entityManager.persist(member);
+		entityManager.close();
+
+		LoginData loginData = new LoginData("yeon@email.com", "test!1234");
+
+		// when & then
+		mockMvc.perform(post("/login")
+				.content(objectMapper.writeValueAsString(loginData))
+				.contentType(MediaType.APPLICATION_JSON))
+			.andDo(print())
+			.andExpect(status().isOk())
+			.andDo(document("login-success",
+				preprocessRequest(prettyPrint()),
+				preprocessResponse(prettyPrint()),
+				requestFields(
+					fieldWithPath("email").type(JsonFieldType.STRING).description("이메일"),
+					fieldWithPath("password").type(JsonFieldType.STRING).description("비밀번호")
+				),
+				responseFields(
+					fieldWithPath("code").type(JsonFieldType.NUMBER).description("코드"),
+					fieldWithPath("status").type(JsonFieldType.STRING).description("상태"),
+					fieldWithPath("message").type(JsonFieldType.STRING).description("메시지"),
+					fieldWithPath("data").type(JsonFieldType.OBJECT).description("응답 데이터"),
+					fieldWithPath("data.accessToken").type(JsonFieldType.STRING).description("Access Token"),
+					fieldWithPath("data.refreshToken").type(JsonFieldType.STRING).description("Refresh Token")
+				)
+			));
+	}
+
+	@Test
+	@DisplayName("일반 로그인 : 실패")
+	@Transactional
+	void loginFail() throws Exception {
+		// given
+		Member member = new Member(
+			null,
+			"yeon@email.com",
+			"yeonise",
+			PasswordEncoder.encrypt("test!1234"),
+			Provider.LOCAL
+		);
+		entityManager.persist(member);
+		entityManager.close();
+
+		LoginData loginData = new LoginData("yeon@email.com", "test!123");
+
+		// when & then
+		mockMvc.perform(post("/login")
+				.content(objectMapper.writeValueAsString(loginData))
+				.contentType(MediaType.APPLICATION_JSON))
+			.andDo(print())
+			.andExpect(status().isUnauthorized())
+			.andDo(document("login-fail",
+				preprocessRequest(prettyPrint()),
+				preprocessResponse(prettyPrint()),
+				requestFields(
+					fieldWithPath("email").type(JsonFieldType.STRING).description("이메일"),
+					fieldWithPath("password").type(JsonFieldType.STRING).description("비밀번호")
+				),
+				responseFields(
+					fieldWithPath("code").type(JsonFieldType.NUMBER).description("코드"),
+					fieldWithPath("status").type(JsonFieldType.STRING).description("상태"),
+					fieldWithPath("message").type(JsonFieldType.STRING).description("메시지"),
+					fieldWithPath("data").type(JsonFieldType.NULL).description("응답 데이터")
+				)
+			));
+	}
+
+	@Test
+	@DisplayName("토큰 재발급 : 성공")
+	void reissueSuccess() throws Exception {
+		// given
+		Long MEMBER_ID = 1L;
+		String refreshToken = tokenManager.issueTokenPair(MEMBER_ID).getRefreshToken();
+
+		// when & then
+		mockMvc.perform(post("/reissue")
+				.header(HttpHeaders.AUTHORIZATION, "Bearer " + refreshToken))
+			.andDo(print())
+			.andExpect(status().isOk())
+			.andDo(document("reissue-success",
+				preprocessRequest(prettyPrint()),
+				preprocessResponse(prettyPrint()),
+				responseFields(
+					fieldWithPath("code").type(JsonFieldType.NUMBER).description("코드"),
+					fieldWithPath("status").type(JsonFieldType.STRING).description("상태"),
+					fieldWithPath("message").type(JsonFieldType.STRING).description("메시지"),
+					fieldWithPath("data").type(JsonFieldType.OBJECT).description("응답 데이터"),
+					fieldWithPath("data.accessToken").type(JsonFieldType.STRING).description("Access Token")
+				)
+			));
+	}
+
+	@Test
+	@DisplayName("토큰 재발급 : 실패")
+	void reissueFail() throws Exception {
+		// given
+		Long MEMBER_ID = 1L;
+		String accessToken = tokenManager.issueTokenPair(MEMBER_ID).getAccessToken();
+
+		// when & then
+		mockMvc.perform(post("/reissue")
+				.header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+			.andDo(print())
+			.andExpect(status().isUnauthorized())
+			.andDo(document("reissue-fail",
+				preprocessRequest(prettyPrint()),
+				preprocessResponse(prettyPrint()),
+				responseFields(
+					fieldWithPath("code").type(JsonFieldType.NUMBER).description("코드"),
+					fieldWithPath("status").type(JsonFieldType.STRING).description("상태"),
+					fieldWithPath("message").type(JsonFieldType.STRING).description("메시지"),
+					fieldWithPath("data").type(JsonFieldType.NULL).description("응답 데이터")
+				)
+			));
+	}
+
+	@Test
+	@DisplayName("인증 실패 : 만료된 토큰")
+	void requestWithExpiredToken() throws Exception {
+		// given
+		String accessToken = "eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwicmVmcmVzaCI6ZmFsc2UsImlzcyI6InRpZ2VycyIsImlhdCI6MTcwMTIzMzIzMSwiZXhwIjoxNzAxMjM1MDMxfQ.wtPrTsa9lwGxmAj0HhD-FZde9T-4Fpdyz28pE3kpUC8";
+
+		// when & then
+		mockMvc.perform(post("/reissue")
+				.header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+			.andDo(print())
+			.andExpect(status().isUnauthorized())
+			.andDo(document("expired-token",
+				preprocessRequest(prettyPrint()),
+				preprocessResponse(prettyPrint()),
+				responseFields(
+					fieldWithPath("code").type(JsonFieldType.NUMBER).description("코드"),
+					fieldWithPath("status").type(JsonFieldType.STRING).description("상태"),
+					fieldWithPath("message").type(JsonFieldType.STRING).description("메시지"),
+					fieldWithPath("data").type(JsonFieldType.NULL).description("응답 데이터")
+				)
+			));
+	}
+}

--- a/src/test/java/site/onandoff/auth/AuthTest.java
+++ b/src/test/java/site/onandoff/auth/AuthTest.java
@@ -112,6 +112,36 @@ class AuthTest extends IntegrationTestSupport {
 	}
 
 	@Test
+	@DisplayName("일반 로그인 : 입력 형식 오류")
+	void loginValidFail() throws Exception {
+		// given
+		LoginData loginData = new LoginData("yeon@email.c", "test1234");
+
+		// when & then
+		mockMvc.perform(post("/login")
+				.content(objectMapper.writeValueAsString(loginData))
+				.contentType(MediaType.APPLICATION_JSON))
+			.andDo(print())
+			.andExpect(status().isBadRequest())
+			.andDo(document("login-valid-fail",
+				preprocessRequest(prettyPrint()),
+				preprocessResponse(prettyPrint()),
+				requestFields(
+					fieldWithPath("email").type(JsonFieldType.STRING).description("이메일"),
+					fieldWithPath("password").type(JsonFieldType.STRING).description("비밀번호")
+				),
+				responseFields(
+					fieldWithPath("code").type(JsonFieldType.NUMBER).description("코드"),
+					fieldWithPath("status").type(JsonFieldType.STRING).description("상태"),
+					fieldWithPath("message").type(JsonFieldType.NULL).description("메시지"),
+					fieldWithPath("data").type(JsonFieldType.ARRAY).description("응답 데이터"),
+					fieldWithPath("data[].field").type(JsonFieldType.STRING).description("필드"),
+					fieldWithPath("data[].message").type(JsonFieldType.STRING).description("에러 메시지")
+				)
+			));
+	}
+
+	@Test
 	@DisplayName("토큰 재발급 : 성공")
 	void reissueSuccess() throws Exception {
 		// given

--- a/src/test/java/site/onandoff/auth/AuthTest.java
+++ b/src/test/java/site/onandoff/auth/AuthTest.java
@@ -212,4 +212,25 @@ class AuthTest extends IntegrationTestSupport {
 				)
 			));
 	}
+
+	@Test
+	@DisplayName("인증 실패 : Authorization Header 오류")
+	void requestWithInvalidAuthorizationHeader() throws Exception {
+		// when & then
+		mockMvc.perform(post("/reissue")
+				.header(HttpHeaders.AUTHORIZATION, "Bear "))
+			.andDo(print())
+			.andExpect(status().isBadRequest())
+			.andDo(document("invalid-authorization-header",
+				preprocessRequest(prettyPrint()),
+				preprocessResponse(prettyPrint()),
+				responseFields(
+					fieldWithPath("code").type(JsonFieldType.NUMBER).description("코드"),
+					fieldWithPath("status").type(JsonFieldType.STRING).description("상태"),
+					fieldWithPath("message").type(JsonFieldType.STRING).description("메시지"),
+					fieldWithPath("data").type(JsonFieldType.NULL).description("응답 데이터")
+				)
+			));
+	}
+
 }

--- a/src/test/resources/org/springframework/restdocs/templates/request-fields.snippet
+++ b/src/test/resources/org/springframework/restdocs/templates/request-fields.snippet
@@ -1,0 +1,14 @@
+==== Request Fields
+|===
+|Path|Type|Optional|Description
+
+{{#fields}}
+
+|{{#tableCellContent}}`+{{path}}+`{{/tableCellContent}}
+|{{#tableCellContent}}`+{{type}}+`{{/tableCellContent}}
+|{{#tableCellContent}}{{#optional}}O{{/optional}}{{/tableCellContent}}
+|{{#tableCellContent}}{{description}}{{/tableCellContent}}
+
+{{/fields}}
+
+|===

--- a/src/test/resources/org/springframework/restdocs/templates/response-fields.snippet
+++ b/src/test/resources/org/springframework/restdocs/templates/response-fields.snippet
@@ -1,0 +1,14 @@
+==== Response Fields
+|===
+|Path|Type|Optional|Description
+
+{{#fields}}
+
+|{{#tableCellContent}}`+{{path}}+`{{/tableCellContent}}
+|{{#tableCellContent}}`+{{type}}+`{{/tableCellContent}}
+|{{#tableCellContent}}{{#optional}}O{{/optional}}{{/tableCellContent}}
+|{{#tableCellContent}}{{description}}{{/tableCellContent}}
+
+{{/fields}}
+
+|===


### PR DESCRIPTION
## Key Feature

**JWT**를 사용한 인증 기능을 구현했습니다.

- 로그인 요청 시, Authorization Header를 검사하지 않습니다.
- 로그인 성공 응답: access token + refresh token
- 로그아웃 및 토큰 만료 관련 작업은 클라이언트 어플리케이션에서 수행합니다.
- 토큰 재발급 요청 시, Authorization Header에 유효한 refresh token이 존재하는지 검사합니다.
- 토큰 재발급 성공 응답: access token

#### Documents List

- Authentication API
  - 일반 로그인 : 성공
  - 일반 로그인 : 실패
  - 일반 로그인 : 입력 형식 오류
  - 토큰 재발급 : 성공
  - 토큰 재발급 : 실패
  - 인증 실패 : Authorization Header 오류
  - 인증 실패 : 만료된 토큰
 
## To reviewer

1. **controller - service - repository** 까지 한 번에 통합 테스트를 수행하는 방법으로 테스트 코드를 작성해보았습니다. (모든 모듈이 함께 제대로 동작하는지 확인 + mock 지양)
2. **큰 통합 테스트 + 중요한 단위 테스트**와 같은 형식으로 테스트 코드 작성 방향을 고민 중
3. 개발하면서 사용한 `application.yml` 이나 `schema.sql` 은 Notion에 올려두었습니다.
4. 테스트를 독립적으로 수행하기 위해 메서드 수행 전마다 `schema.sql`을 사용하여 데이터베이스를 초기화하는 작업을 수행하고 있습니다. 보다 경량화된 작업으로 테스트의 독립성을 유지할 수 있는 방법이 있을까요?

## Relationship Diagram

추가로 `auth.application` 패키지 내 클래스 관계도를 첨부합니다.
개선되었으면 하는 부분이 있다면 알려주세요 🐥

<img width="1069" alt="image" src="https://github.com/mujik-tigers/on-and-off/assets/105152276/2216925a-6f1c-44bd-9f9b-985b804d7273">

Close #12 
